### PR TITLE
Fix misspelling of Ethereum

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -291,7 +291,7 @@ export default function Main() {
               className="h-16 mr-4"
               alt="Patreon"
               src="assets/external/eth-material.svg" />
-            <span className="rubik text-xl">Donate Etherem</span>
+            <span className="rubik text-xl">Donate Ethereum</span>
           </a>
           <a
             className="flex flex-row justify-start items-center shadow mx-4 my-4"


### PR DESCRIPTION
I know, it's a tiny change, but it's a bit of an eyesore. ;)
I fixed the spelling of Ethereum on the landing page.